### PR TITLE
Gateway manifests

### DIFF
--- a/.citools.xml
+++ b/.citools.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+<project name="manifest" path=".ci/manifest" clone-depth="1" groups="ci" >
+      <linkfile src=".clang-format" dest=".clang-format" />
+      <linkfile src=".pre-commit-config.yaml" dest=".pre-commit-config.yaml" />
+      <linkfile src=".flake8" dest=".flake8" />
+      <linkfile src=".shellcheck" dest=".shellcheck" />
+      <linkfile src="dev-requirements.txt" dest="dev-requirements.txt" />
+  </project>
+</manifest>

--- a/.remotes.xml
+++ b/.remotes.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+    <remote name="github"
+            fetch="https://github.com/wirepas"
+            pushurl="git@github.com:wirepas" />
+
+    <default revision="refs/heads/master"
+             upstream="refs/heads/master"
+             remote="github"
+             dest-branch="dev"
+             sync-s="true"
+             sync-c="true"
+             sync-tags="true"
+             sync-j="4" />
+</manifest>

--- a/_remotes.xml
+++ b/_remotes.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote  name="github"
-           fetch="https://git@github.com/wirepas" />
+    <remote name="github"
+            fetch="https://github.com/wirepas"
+            pushurl="git@github.com:wirepas" />
+
+    <remote name="private"
+            fetch="ssh://git@github.com/wirepas"
+            pushurl="ssh://git@github.com:wirepas" />
 </manifest>

--- a/gateway/dev.xml
+++ b/gateway/dev.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <include name=".remotes.xml" />
+  <project name="gateway" path="." groups="gateway" />
+
+  <project name="c-mesh-api" path="sink_service/c-mesh-api" groups="gateway, dualmcu"/>
+  <include name=".citools.xml" />
+
+
+</manifest>

--- a/gateway/stable.xml
+++ b/gateway/stable.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <include name=".remotes.xml" />
+  <include name="_remotes.xml" />
   <default revision="refs/heads/master"
            remote="github"
            sync-j="4" />
   <notice>
-    This file will be removed, please use gateway/dev.xml or gateway/stable.xml instead.
+    Your sources have been sync'd successfully.
   </notice>
 
   <project name="gateway"
            groups="gateway"
            path="." />
+
+  <project name="backend-apis"
+           groups="apis"
+           path="public-apis" />
 
   <project name="c-mesh-api"
            groups="apis"


### PR DESCRIPTION
This change moves the gateway manifest into gateway/.

The folder will contain two manifests:

-   dev.xml: pointing to master or other dev locations as needed

-   stable.xml: latest release

With this change, repo usage should rely on refs/tags instead of
expecting a branch to exist. The goal behind this is to keep
the repository with a manageable size as we expect other
components to be added in the future.